### PR TITLE
Removes return FALSE after exceptions

### DIFF
--- a/src/SimpleExcel/Parser/CSV.php
+++ b/src/SimpleExcel/Parser/CSV.php
@@ -28,14 +28,13 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 	 * 
 	 * @param	int	$row_num	Row number
 	 * @param	int	$col_num	Column number
-	 * @return	mixed			Returns an array or FALSE if cell doesn't exist
+	 * @return	mixed			Returns an array
 	 */
 	public function getCell($row_num, $col_num){
 		
 		// check whether the cell exists
 		if(!isset($this->table_arr[$row_num-1][$col_num-1])){
 			throw new Exception('Cell '.$row_num.','.$col_num.' doesn\'t exist');
-			return FALSE;
 		}
 		return $this->table_arr[$row_num-1][$col_num-1];
 	}
@@ -45,14 +44,13 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 	 * 
 	 * @param	int	$row_num	Row number
 	 * @param	int	$col_num	Column number
-	 * @return	mixed			Returns 'String' or FALSE if cell doesn't exist
+	 * @return	mixed			Returns ''String'
 	 */
 	public function getCellDatatype($row_num, $col_num){
 		
 		// check whether the cell exists
 		if(!isset($this->table_arr[$row_num-1][$col_num-1])){
 			throw new Exception('Cell '.$row_num.','.$col_num.' doesn\'t exist');
-			return FALSE;
 		}
 		return 'String';
 	}
@@ -61,15 +59,14 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 	 * Get data of the specified column as an array
 	 * 
 	 * @param	int		$col_num	Column number
-	 * @param	bool	$val_only	Ignored in CSV
-	 * @return	mixed				Returns an array or FALSE if table doesn't exist
+	 * @param	bool		$val_only	Ignored in CSV
+	 * @return	mixed				Returns an array
 	 */
 	public function getColumn($col_num, $val_only = TRUE){
 		$col_arr = array();
 		
 		if(!isset($this->table_arr[0][$col_num-1])){
 			throw new Exception('Column '.$col_num.' doesn\'t exist');
-			return FALSE;
 		}
 
 		// get the specified column within every row
@@ -91,7 +88,6 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 			return $this->table_arr;
 		} else {
 			throw new Exception('Field is empty');
-			return FALSE;
 		}
 	}
 	
@@ -99,13 +95,12 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 	 * Get data of the specified row as an array
 	 * 
 	 * @param	int		$row_num	Row number
-	 * @param	bool	$val_only	Ignored in CSV
-	 * @return	mixed				Returns an array FALSE if row doesn't exist
+	 * @param	bool		$val_only	Ignored in CSV
+	 * @return	mixed				Returns an array
 	 */
 	public function getRow($row_num, $val_only = TRUE){
 		if(!isset($this->table_arr[$row_num-1])){
-			throw new Exception('Row '.$row_num.' doesn\'t exist');			
-			return FALSE;				
+			throw new Exception('Row '.$row_num.' doesn\'t exist');						
 		}
 
 		// return the array			
@@ -116,38 +111,36 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
 	 * Load the CSV file to be parsed
 	 * 
 	 * @param	string	$file_url	Path to CSV file
-	 * @return	bool				Returns TRUE if file exist and valid, FALSE if does'nt
+	 * @return	bool			Returns TRUE if file exist and valid, FALSE if does'nt
 	 */
 	public function loadFile($file_path){
 
 		$file_extension = strtoupper(pathinfo($file_path, PATHINFO_EXTENSION));
 
-		if(!file_exists($file_path)){
+		if (!file_exists($file_path)) {
 			throw new Exception('File doesn\'t exist');
-			return FALSE;
-		} else if($file_extension != 'CSV'){
+		} else if ($file_extension != 'CSV'){
 			throw new Exception('File isn\'t a CSV Spreadsheet');
-			return FALSE;
 		}
 		
-        if(($handle = fopen($file_path, 'r')) !== FALSE){
+        	if (($handle = fopen($file_path, 'r')) !== FALSE) {
         
-            $this->table_arr = array();
-           
-            // first, assume the delimiter is semicolon
-            while(($line = fgetcsv($handle, 0, ';')) !== FALSE){
-                // check the number of values in each line
-                if(count($line) > 1){
-                    array_push($this->table_arr, $line);
-                } else {
-                    // if a line only contains 1 value
-                    // maybe our assumption in the beginning was wrong
-                    // empty the array back
-                    $this->table_arr = array();
-                    // break this loop
-                    break;
-                }
-            }
+	            $this->table_arr = array();
+	           
+	            // first, assume the delimiter is semicolon
+	            while(($line = fgetcsv($handle, 0, ';')) !== FALSE){
+	                // check the number of values in each line
+	                if(count($line) > 1){
+	                    array_push($this->table_arr, $line);
+	                } else {
+	                    // if a line only contains 1 value
+	                    // maybe our assumption in the beginning was wrong
+	                    // empty the array back
+	                    $this->table_arr = array();
+	                    // break this loop
+	                    break;
+	                }
+	            }
             
             // if the array is still empty, maybe because the values are separated by commas
             if(count($this->table_arr) < 1){
@@ -161,11 +154,9 @@ class SimpleExcel_Parser_CSV implements SimpleExcel_Parser_Interface
             
         } else {
             throw new Exception('Error reading the file');
-			return FALSE;
         }
 					
 		// load succeed :)
 		return TRUE;
 	}
 }
-?>


### PR DESCRIPTION
Removes unnecessary "return FALSE;" statements following exceptions, and from the class documentation. Tried to do some source formatting cleanup.
