### PR TITLE
Autoloader is now a easily unregisterable function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ php:
   - 5.3
 
 before_script:
-  - pear channel-discover pear.phpunit.de
-  - pear install --alldeps phpunit/PHP_Invoker
-  - pear install --alldeps phpunit/DbUnit
-  - pear install --alldeps phpunit/PHPUnit_Selenium
-  - pear install --alldeps phpunit/PHPUnit_Story
-  - phpenv rehash
+  - "mkdir -p ~/.composer"
+  - composer self-update
+  - composer install
 
 script: phpunit --configuration test/phpunit.xml
 

--- a/src/SimpleExcel/SimpleExcel.php
+++ b/src/SimpleExcel/SimpleExcel.php
@@ -39,9 +39,7 @@ use  SimpleExcel\Exception\SimpleExcelException;
 
 if (!class_exists('Composer\\Autoload\\ClassLoader', false)){
     // autoload all interfaces & classes
-    spl_autoload_register(function($class_name){
-        if($class_name != 'SimpleExcel') require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, substr($class_name, strlen('SimpleExcel\\'))).'.php');
-    });
+    spl_autoload_register(array(__NAMESPACE__.'\\SimpleExcel', 'autoLoader'));
 }
 
 /**
@@ -122,5 +120,14 @@ class SimpleExcel
     public function convertTo($filetype){
         $this->constructWriter($filetype);
         $this->writer->setData($this->parser->getField());
+    }
+
+    /**
+     * Autoloader
+     *
+     * @param   string   $class_name The class we want to load
+     */
+    public static function autoLoader($class_name){
+        if($class_name != 'SimpleExcel') require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, substr($class_name, strlen('SimpleExcel\\'))).'.php');
     }
 }


### PR DESCRIPTION
Closures can't be unregistered easily: AFAIK you must unregister
all autoloading functions and then add back those that you didn't
want to exclude in the first place.

This commit will allow you to unregister the autoloader instance
created by this package by simply doing:

spl_autoload_unregister(array('SimpleExcel\\SimpleExcel', 'autoLoader'));