### PR TITLE
Added option for add row method in BaseWrite to add the row to the be…

### DIFF
--- a/src/SimpleExcel/Writer/BaseWriter.php
+++ b/src/SimpleExcel/Writer/BaseWriter.php
@@ -43,15 +43,20 @@ abstract class BaseWriter implements IWriter
 
     /**
      * Adding row data to table
-     * 
+     *
      * @param   array   $values An array contains ordered value for every cell
+     * @param   bool    Check if row goes at the beginning or end of array
      * @return  void
      */
-    public function addRow($values){
+    public function addRow($values, $end = TRUE)
+    {
         if (!is_array($values)) {
             $values = array($values);
         }
-        array_push($this->tabl_data, $values);
+        if ($end) {
+            array_push($this->tabl_data, $values);
+        }
+        array_unshift($this->tabl_data, $values);
     }
     
     /**


### PR DESCRIPTION
Added option for add row method in BaseWrite to add the row to the beginning of an array or the end of the array. By default, it adds to the end just like it originally did. Now users will have the option to unshift the array to create headers. 