### PR TITLE
Catch libxml errors & fixed minor errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ php:
   - 5.3
 
 before_script:
-  - pear channel-discover pear.phpunit.de
-  - pear install --alldeps phpunit/PHP_Invoker
-  - pear install --alldeps phpunit/DbUnit
-  - pear install --alldeps phpunit/PHPUnit_Selenium
-  - pear install --alldeps phpunit/PHPUnit_Story
-  - phpenv rehash
+  - "mkdir -p ~/.composer"
+  - composer self-update
+  - composer install
 
 script: phpunit --configuration test/phpunit.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: php
 
 php:
-  - 5.4
   - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+
+sudo: false
 
 before_script:
   - "mkdir -p ~/.composer"

--- a/src/SimpleExcel/Parser/BaseParser.php
+++ b/src/SimpleExcel/Parser/BaseParser.php
@@ -7,15 +7,15 @@ use SimpleExcel\Spreadsheet\Workbook;
 
 /**
  * SimpleExcel class for parsing HTML table
- *  
+ *
  * @author  Faisalman
  * @package SimpleExcel
- */ 
+ */
 abstract class BaseParser implements IParser
 {
     /**
     * Holds the workbook instance
-    * 
+    *
     * @access   protected
     * @var      Workbook
     */
@@ -23,40 +23,36 @@ abstract class BaseParser implements IParser
 
     /**
     * Defines valid file extension
-    * 
+    *
     * @access   protected
     * @var      string
     */
     protected $file_extension = '';
 
     /**
-    * @param    Workbook    reference to workbook
+    * @param Workbook $workbook reference to workbook
     */
-    public function __construct(&$workbook) {
+    public function __construct(Workbook &$workbook) {
         $this->workbook = &$workbook;
     }
-    
+
     /**
     * Check whether file exists, valid, and readable
-    * 
+    *
     * @param    string  $file_path  Path to file
     * @return   bool
-    * @throws   Exception           If file being loaded doesn't exist
-    * @throws   Exception           If file extension doesn't match
-    * @throws   Exception           If error reading the file
+    * @throws   \Exception          If file being loaded doesn't exist
+    * @throws   \Exception          If file extension doesn't match
+    * @throws   \Exception          If error reading the file
     */
     protected function checkFile($file_path) {
-    
         // file exists?
         if (!file_exists($file_path)) {
-        
             throw new \Exception('File '.$file_path.' doesn\'t exist', SimpleExcelException::FILE_NOT_FOUND);
-        
         // extension valid?
-        } else if (($handle = fopen($file_path, 'r')) === FALSE) {            
-        
-            throw new \Exception('Error reading the file in'.$file_path, SimpleExcelException::ERROR_READING_FILE);
+        } else if (($handle = fopen($file_path, 'r')) === FALSE) {
             fclose($handle);
+            throw new \Exception('Error reading the file in'.$file_path, SimpleExcelException::ERROR_READING_FILE);
         } else {
             return TRUE;
         }
@@ -64,12 +60,12 @@ abstract class BaseParser implements IParser
 
 	/**
 	* Load the file to be parsed
-	* 
+	*
 	* @param    string  $file_path  Path to file
 	* @param    array   $options    Options
-    * @throws   Exception           If file being loaded doesn't exist
-    * @throws   Exception           If file extension doesn't match
-    * @throws   Exception           If error reading the file
+    * @throws   \Exception          If file being loaded doesn't exist
+    * @throws   \Exception          If file extension doesn't match
+    * @throws   \Exception          If error reading the file
 	*/
 	public function loadFile ($file_path, $options = NULL) {
 	    if ($this->checkFile($file_path)) {

--- a/src/SimpleExcel/Parser/HTMLParser.php
+++ b/src/SimpleExcel/Parser/HTMLParser.php
@@ -2,34 +2,33 @@
 
 namespace SimpleExcel\Parser;
 
-use SimpleExcel\Enums\SimpleExcelException;
 use SimpleExcel\Spreadsheet\Workbook;
 use SimpleExcel\Spreadsheet\Worksheet;
 
 /**
  * SimpleExcel class for parsing HTML table
- *  
+ *
  * @author  Faisalman
- * @package SimpleExcel
- */ 
+ * @package SimpleExcel\Parser
+ */
 class HTMLParser extends BaseParser implements IParser
 {
     /**
-    * Defines valid file extension
-    * 
-    * @access   protected
-    * @var      string
-    */
+     * Defines valid file extension
+     *
+     * @access   protected
+     * @var      string
+     */
     protected $file_extension = 'html';
-    
+
     /**
-    * Process the loaded file/string
-    * 
-    * @param    DOMDocument $html   DOMDocument object of HTML
-    */
+     * Process the loaded file/string
+     *
+     * @param   \DOMDocument $html   DOMDocument object of HTML
+     */
     protected function parseDOM($html){
         $this->workbook = new Workbook();
-        $tables = $html->getElementsByTagName('table');    
+        $tables = $html->getElementsByTagName('table');
         foreach ($tables as $table) {
             $sheet = new Worksheet();
             $table_child = $table->childNodes;
@@ -48,7 +47,7 @@ class HTMLParser extends BaseParser implements IParser
                                 }
                                 $sheet->insertRecord($row);
                             }
-                        }                        
+                        }
                     } else if ($twrap->nodeName === "tr") {
                         $row = array();
                         $twrap_child = $twrap->childNodes;
@@ -64,16 +63,20 @@ class HTMLParser extends BaseParser implements IParser
             $this->workbook->insertWorksheet($sheet);
         }
     }
-        
+
     /**
-    * Load the string to be parsed
-    * 
-    * @param    string  $str        String with HTML format
-	* @param    array   $options    Options
-    */
-    public function loadString($str, $options = NULL){
-        $html = new \DOMDocument();        
-        $html->loadHTML($str);
+     * Load the string to be parsed
+     *
+     * @param    string  $str        String with HTML format
+     * @param    array   $options    Options
+     */
+    public function loadString($str, $options){
+        $html = new \DOMDocument('1.0', 'UTF-8');
+        $sp = mb_convert_encoding($str, 'HTML-ENTITIES', "UTF-8");
+
+        $html->loadHTML($sp);
+        $html->encoding = 'UTF-8';
+
         $this->parseDOM($html);
     }
 }

--- a/src/SimpleExcel/Parser/XLSXParser.php
+++ b/src/SimpleExcel/Parser/XLSXParser.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 namespace SimpleExcel\Parser;
 
 use SimpleExcel\Enums\Datatype;
@@ -10,7 +10,7 @@ use SimpleExcel\Spreadsheet\Worksheet;
 
 /**
  * SimpleExcel class for parsing Microsoft Excel XLSX Spreadsheet
- *  
+ *
  * @author  Faisalman
  * @package SimpleExcel
  */
@@ -18,7 +18,7 @@ class XLSXParser extends BaseParser
 {
     /**
     * Defines valid file extension
-    * 
+    *
     * @access   protected
     * @var      string
     */
@@ -26,7 +26,7 @@ class XLSXParser extends BaseParser
 
     /**
     * Load the file to be parsed
-    * 
+    *
     * @param    string  $file_path  Path to file
     * @param    array   $options    Options
     * @throws   Exception           If file being loaded doesn't exist
@@ -35,11 +35,11 @@ class XLSXParser extends BaseParser
     */
     public function loadFile ($file_path, $options = NULL) {
         if ($this->checkFile($file_path)) {
-            
+
             // read uncompressed xlsx contents
             $zip = zip_open($file_path);
             $xml_worksheets = array();
-            $xml_sharedstrings = array(); 
+            $xml_sharedstrings = array();
             while($zip_entry = zip_read($zip))
             {
                 if(preg_match("/xl\/worksheets\/sheet\d+\.xml/", zip_entry_name($zip_entry)))
@@ -66,7 +66,7 @@ class XLSXParser extends BaseParser
                 }
             }
             zip_close($zip);
-            
+
             // map sheets <-> sharedstrings into simpleexcel workbook
             $this->Workbook = new Workbook();
             foreach ($xml_worksheets as $worksheet) {

--- a/src/SimpleExcel/Parser/XLSXParser.php
+++ b/src/SimpleExcel/Parser/XLSXParser.php
@@ -2,8 +2,6 @@
 
 namespace SimpleExcel\Parser;
 
-use SimpleExcel\Enums\Datatype;
-use SimpleExcel\Enums\SimpleExcelException;
 use SimpleExcel\Spreadsheet\Cell;
 use SimpleExcel\Spreadsheet\Workbook;
 use SimpleExcel\Spreadsheet\Worksheet;
@@ -12,40 +10,44 @@ use SimpleExcel\Spreadsheet\Worksheet;
  * SimpleExcel class for parsing Microsoft Excel XLSX Spreadsheet
  *
  * @author  Faisalman
- * @package SimpleExcel
+ * @package SimpleExcel\Parser
  */
 class XLSXParser extends BaseParser
 {
     /**
-    * Defines valid file extension
-    *
-    * @access   protected
-    * @var      string
-    */
+     * Defines valid file extension
+     *
+     * @access   protected
+     * @var      string
+     */
     protected $file_extension = 'xlsx';
 
     /**
-    * Load the file to be parsed
-    *
-    * @param    string  $file_path  Path to file
-    * @param    array   $options    Options
-    * @throws   Exception           If file being loaded doesn't exist
-    * @throws   Exception           If file extension doesn't match
-    * @throws   Exception           If error reading the file
-    */
-    public function loadFile ($file_path, $options = NULL) {
-        if ($this->checkFile($file_path)) {
+     * @var Workbook
+     */
+    protected $Workbook;
 
+    /**
+     * Load the file to be parsed
+     *
+     * @param    string  $file_path  Path to file
+     * @param    array   $options    Options
+     * @throws   \Exception          If file being loaded doesn't exist
+     * @throws   \Exception          If file extension doesn't match
+     * @throws   \Exception          If error reading the file
+     */
+    public function loadFile ($file_path, $options = NULL) {
+        error_log(gettype($this->Workbook));
+        if ($this->checkFile($file_path)) {
             // read uncompressed xlsx contents
             $zip = zip_open($file_path);
             $xml_worksheets = array();
             $xml_sharedstrings = array();
-            while($zip_entry = zip_read($zip))
-            {
-                if(preg_match("/xl\/worksheets\/sheet\d+\.xml/", zip_entry_name($zip_entry)))
-                {
-                    if(zip_entry_open($zip, $zip_entry))
-                    {
+
+            while($zip_entry = zip_read($zip)) {
+                error_log(zip_entry_name($zip_entry));
+                if (preg_match('#xl\/worksheets\/sheet\d+\.xml#', zip_entry_name($zip_entry))) {
+                    if (zip_entry_open($zip, $zip_entry)) {
                         $xml_length = zip_entry_filesize($zip_entry);
                         $xml_read = zip_entry_read($zip_entry, $xml_length);
                         $xml_simplexml = simplexml_load_string($xml_read);
@@ -53,10 +55,9 @@ class XLSXParser extends BaseParser
                         array_push($xml_worksheets, json_decode(json_encode((array)$xml_array['sheetData']), 1));
                     }
                 }
-                if(preg_match("/xl\/sharedStrings\.xml/", zip_entry_name($zip_entry)))
-                {
-                    if(zip_entry_open($zip, $zip_entry))
-                    {
+
+                if (preg_match('#/xl\/sharedStrings\.xml/#', zip_entry_name($zip_entry))) {
+                    if (zip_entry_open($zip, $zip_entry)) {
                         $xml_length = zip_entry_filesize($zip_entry);
                         $xml_read = zip_entry_read($zip_entry, $xml_length);
                         $xml_simplexml = simplexml_load_string($xml_read);
@@ -65,6 +66,7 @@ class XLSXParser extends BaseParser
                     }
                 }
             }
+
             zip_close($zip);
 
             // map sheets <-> sharedstrings into simpleexcel workbook
@@ -80,8 +82,14 @@ class XLSXParser extends BaseParser
                     }
                     $sheet->insertRecord($record);
                 }
+
                 $this->Workbook->insertWorksheet($sheet);
             }
         }
+    }
+
+    public function loadString($str, $options)
+    {
+        // @TODO
     }
 }

--- a/src/SimpleExcel/Parser/XMLParser.php
+++ b/src/SimpleExcel/Parser/XMLParser.php
@@ -5,7 +5,6 @@ namespace SimpleExcel\Parser;
 use SimpleExcel\Enums\Datatype;
 use SimpleExcel\Enums\SimpleExcelException;
 use SimpleExcel\Spreadsheet\Cell;
-use SimpleExcel\Spreadsheet\Workbook;
 use SimpleExcel\Spreadsheet\Worksheet;
 
 /**

--- a/src/SimpleExcel/Parser/XMLParser.php
+++ b/src/SimpleExcel/Parser/XMLParser.php
@@ -10,35 +10,48 @@ use SimpleExcel\Spreadsheet\Worksheet;
 
 /**
  * SimpleExcel class for parsing Microsoft Excel 2003 XML Spreadsheet
- *  
+ *
  * @author  Faisalman
  * @package SimpleExcel
- */ 
+ */
 class XMLParser extends BaseParser
-{    
+{
     /**
     * Defines valid file extension
-    * 
+    *
     * @access   protected
     * @var      string
     */
     protected $file_extension = 'xml';
-    
+
     /**
      * Load the string to be parsed
      *
      * @param    string  $str       String with XML format
 	 * @param    array   $options   Options
-     * @throws   Exception               If document namespace invalid
+     * @throws   \Exception         If document namespace invalid
      * @return bool
      */
     public function loadString ($str, $options = NULL) {
+        libxml_use_internal_errors(true);
         $xml = simplexml_load_string($str);
-        $this->workbook = new Workbook();
+        $errors = libxml_get_errors();
+
+        if (is_array($errors) && !empty($errors)) {
+            /** @var \LibXMLError $error */
+            $error = $errors[0];
+            throw new \Exception(
+                sprintf('The file is corrupt. %s', $error->message)
+            );
+        }
+        libxml_use_internal_errors(false);
+
         $xmlns = $xml->getDocNamespaces();
-        if ($xmlns['ss'] != 'urn:schemas-microsoft-com:office:spreadsheet') {
+
+        if (!isset($xmlns['ss']) || $xmlns['ss'] != 'urn:schemas-microsoft-com:office:spreadsheet') {
             throw new \Exception('Document namespace isn\'t a valid Excel XML 2003 Spreadsheet', SimpleExcelException::INVALID_DOCUMENT_NAMESPACE);
         }
+
         foreach($xml->Worksheet as $worksheet) {
             $sheet = new Worksheet();
             $col_max = 0;
@@ -60,7 +73,7 @@ class XMLParser extends BaseParser
                         for ($i = 1; $i < $gap; $i++) {
                             array_push($record, new Cell(''));
                         }
-                    }                    
+                    }
                     $data_attrs = $cell->Data->xpath('@ss:*');
                     $cell_datatype = $data_attrs['Type'];
                     switch ($cell_datatype) {

--- a/src/SimpleExcel/SimpleExcel.php
+++ b/src/SimpleExcel/SimpleExcel.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Simple Excel
- * 
+ *
  * A PHP library with simplistic approach
  * Easily parse/convert/write between Microsoft Excel XML/CSV/TSV/HTML/JSON/etc formats
- *  
+ *
  * Copyright (c) 2011-2013 Faisalman <fyzlman@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -16,7 +16,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- * 
+ *
  * @author      Faisalman
  * @copyright   2011-2013 (c) Faisalman
  * @license     http://www.opensource.org/licenses/mit-license
@@ -48,7 +48,7 @@ if (!class_exists('Composer\\Autoload\\ClassLoader', false)){
 
 /**
  * SimpleExcel main class
- * 
+ *
  * @author Faisalman
  * @package SimpleExcel
  */
@@ -58,7 +58,7 @@ class SimpleExcel
     * @var IParser
     */
     protected $parser;
-    
+
     /**
     * @var string
     */
@@ -68,22 +68,22 @@ class SimpleExcel
     * @var array
     */
     protected $validParserTypes;
-    
+
     /**
     * @var array
     */
     protected $validWriterTypes;
-    
+
     /**
     * @var IWriter
     */
     protected $writer;
-    
+
     /**
     * @var string
     */
     protected $writerType;
-    
+
     /**
     * @var Workbook
     */
@@ -91,14 +91,14 @@ class SimpleExcel
 
     /**
     * SimpleExcel constructor method
-    * 
+    *
     * @param    string  $filetype   Set the filetype of the file
     */
     public function __construct ($filetype = NULL) {
         $this->workbook = new Workbook();
         $this->validParserTypes = array('XML', 'CSV', 'TSV', 'HTML', 'JSON', 'XLSX');
         $this->validWriterTypes = array('XML', 'CSV', 'TSV', 'HTML', 'JSON');
-        if (isset($filetype)) {
+        if (isset($filetype) && is_scalar($filetype)) {
             $this->setParserType($filetype);
             $this->setWriterType($filetype);
         }
@@ -106,7 +106,7 @@ class SimpleExcel
 
     /**
     * Export data as file
-    * 
+    *
     * @param    string  $target     Where to write the file
     * @param    string  $filetype   Type of the file to be written
     * @param    string  $options    Options
@@ -117,10 +117,10 @@ class SimpleExcel
         $this->setWriterType($fileType);
         $this->writer->exportFile($target, $options);
     }
-    
+
     /**
     * Get specified worksheet
-    * 
+    *
     * @param    int     $index      Worksheet index
     * @return   Worksheet
     * @throws   Exception           If worksheet with specified index is not found
@@ -128,7 +128,7 @@ class SimpleExcel
     public function getWorksheet ($index = 1) {
         return $this->workbook->getWorksheet($index);
     }
-    
+
     /**
     * Get all worksheets
     *
@@ -137,10 +137,10 @@ class SimpleExcel
     public function getWorksheets () {
         return $this->workbook->getWorksheets();
     }
-    
+
     /**
     * Insert a worksheet
-    * 
+    *
     * @param    Worksheet   $worksheet  Worksheet to be inserted
     */
     public function insertWorksheet (Worksheet $worksheet = NULL) {
@@ -149,7 +149,7 @@ class SimpleExcel
 
     /**
     * Load file to parser
-    * 
+    *
     * @param    string  $filepath   Path to file
     * @param    string  $filetype   Set the filetype of the file which will be parsed
     * @param    string  $options    Options
@@ -162,10 +162,10 @@ class SimpleExcel
         $this->setParserType($fileType);
         $this->parser->loadFile($filePath, $options);
     }
-    
+
     /**
     * Load string to parser
-    * 
+    *
     * @param    string  $filepath   Path to file
     * @param    string  $filetype   Set the filetype of the file which will be parsed
     * @throws   Exception           If filetype is not supported
@@ -174,10 +174,10 @@ class SimpleExcel
         $this->setParserType($fileType);
         $this->parser->loadString($string);
     }
-    
+
     /**
     * Remove a worksheet
-    * 
+    *
     * @param    int   $index  Worksheet index to be removed
     */
     public function removeWorksheet ($index) {
@@ -186,7 +186,7 @@ class SimpleExcel
 
     /**
     * Construct a SimpleExcel Parser
-    * 
+    *
     * @param    string  $filetype   Set the filetype of the file which will be parsed (XML/CSV/TSV/HTML/JSON)
     * @throws   Exception           If filetype is not supported
     */
@@ -204,7 +204,7 @@ class SimpleExcel
 
     /**
     * Construct a SimpleExcel Writer
-    * 
+    *
     * @param    string  $filetype   Set the filetype of the file which will be written
     * @throws   Exception           If filetype is not supported
     */
@@ -219,10 +219,10 @@ class SimpleExcel
             $this->writerType = $filetype;
         }
     }
-    
+
     /**
     * Get data as string
-    * 
+    *
     * @param    string  $filetype   Document format for the string to be returned
     * @param    string  $options    Options
     * @return   string

--- a/src/SimpleExcel/SimpleExcel.php
+++ b/src/SimpleExcel/SimpleExcel.php
@@ -41,9 +41,7 @@ use SimpleExcel\Spreadsheet\Worksheet;
 
 if (!class_exists('Composer\\Autoload\\ClassLoader', false)){
     // autoload all interfaces & classes
-    spl_autoload_register(function($class_name){
-        if($class_name != 'SimpleExcel') require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, substr($class_name, strlen('SimpleExcel\\'))).'.php');
-    });
+    spl_autoload_register(array(__NAMESPACE__.'\\SimpleExcel', 'autoLoader'));
 }
 
 /**
@@ -231,5 +229,14 @@ class SimpleExcel
     public function toString ($filetype, $options = NULL) {
         $this->setWriterType($filetype);
         return $this->writer->toString($options);
+    }
+
+    /**
+     * Autoloader
+     *
+     * @param   string   $class_name The class we want to load
+     */
+    public static function autoLoader($class_name){
+        if($class_name != 'SimpleExcel') require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, substr($class_name, strlen('SimpleExcel\\'))).'.php');
     }
 }

--- a/src/SimpleExcel/SimpleExcel.php
+++ b/src/SimpleExcel/SimpleExcel.php
@@ -170,7 +170,7 @@ class SimpleExcel
     */
     public function loadString ($string, $fileType) {
         $this->setParserType($fileType);
-        $this->parser->loadString($string, []);
+        $this->parser->loadString($string, null);
     }
 
     /**

--- a/src/SimpleExcel/SimpleExcel.php
+++ b/src/SimpleExcel/SimpleExcel.php
@@ -53,7 +53,7 @@ if (!class_exists('Composer\\Autoload\\ClassLoader', false)){
 class SimpleExcel
 {
     /**
-    * @var IParser
+    * @var \SimpleExcel\Parser\IParser
     */
     protected $parser;
 
@@ -73,7 +73,7 @@ class SimpleExcel
     protected $validWriterTypes;
 
     /**
-    * @var IWriter
+    * @var \SimpleExcel\Writer\IWriter
     */
     protected $writer;
 
@@ -106,10 +106,10 @@ class SimpleExcel
     * Export data as file
     *
     * @param    string  $target     Where to write the file
-    * @param    string  $filetype   Type of the file to be written
+    * @param    string  $fileType   Type of the file to be written
     * @param    string  $options    Options
-    * @throws   Exception           If filetype is not supported
-    * @throws   Exception           If error writing file
+    * @throws   \Exception          If filetype is not supported
+    * @throws   \Exception          If error writing file
     */
     public function exportFile ($target, $fileType, $options = NULL) {
         $this->setWriterType($fileType);
@@ -121,7 +121,7 @@ class SimpleExcel
     *
     * @param    int     $index      Worksheet index
     * @return   Worksheet
-    * @throws   Exception           If worksheet with specified index is not found
+    * @throws   \Exception          If worksheet with specified index is not found
     */
     public function getWorksheet ($index = 1) {
         return $this->workbook->getWorksheet($index);
@@ -148,13 +148,13 @@ class SimpleExcel
     /**
     * Load file to parser
     *
-    * @param    string  $filepath   Path to file
-    * @param    string  $filetype   Set the filetype of the file which will be parsed
+    * @param    string  $filePath   Path to file
+    * @param    string  $fileType   Set the filetype of the file which will be parsed
     * @param    string  $options    Options
-    * @throws   Exception           If filetype is not supported
-    * @throws   Exception           If file being loaded doesn't exist
-    * @throws   Exception           If file extension doesn't match
-    * @throws   Exception           If error reading the file
+    * @throws   \Exception          If filetype is not supported
+    * @throws   \Exception          If file being loaded doesn't exist
+    * @throws   \Exception          If file extension doesn't match
+    * @throws   \Exception          If error reading the file
     */
     public function loadFile ($filePath, $fileType, $options = NULL) {
         $this->setParserType($fileType);
@@ -164,13 +164,13 @@ class SimpleExcel
     /**
     * Load string to parser
     *
-    * @param    string  $filepath   Path to file
-    * @param    string  $filetype   Set the filetype of the file which will be parsed
-    * @throws   Exception           If filetype is not supported
+    * @param    string  $string     Path to file
+    * @param    string  $fileType   Set the filetype of the file which will be parsed
+    * @throws   \Exception          If filetype is not supported
     */
     public function loadString ($string, $fileType) {
         $this->setParserType($fileType);
-        $this->parser->loadString($string);
+        $this->parser->loadString($string, []);
     }
 
     /**
@@ -186,13 +186,15 @@ class SimpleExcel
     * Construct a SimpleExcel Parser
     *
     * @param    string  $filetype   Set the filetype of the file which will be parsed (XML/CSV/TSV/HTML/JSON)
-    * @throws   Exception           If filetype is not supported
+    * @throws   \Exception          If filetype is not supported
     */
     protected function setParserType($filetype){
         $filetype = strtoupper($filetype);
         if ($filetype != $this->parserType) {
             if(!in_array($filetype, $this->validParserTypes)){
-                throw new \Exception('Filetype '.$filetype.' is not supported', SimpleExcelException::FILETYPE_NOT_SUPPORTED);
+                throw new \Exception(
+                    'Filetype '.$filetype.' is not supported', SimpleExcelException::FILETYPE_NOT_SUPPORTED
+                );
             }
             $parser_class = 'SimpleExcel\\Parser\\'.$filetype.'Parser';
             $this->parser = new $parser_class($this->workbook);
@@ -204,7 +206,7 @@ class SimpleExcel
     * Construct a SimpleExcel Writer
     *
     * @param    string  $filetype   Set the filetype of the file which will be written
-    * @throws   Exception           If filetype is not supported
+    * @throws   \Exception          If filetype is not supported
     */
     protected function setWriterType ($filetype) {
         $filetype = strtoupper($filetype);
@@ -224,7 +226,7 @@ class SimpleExcel
     * @param    string  $filetype   Document format for the string to be returned
     * @param    string  $options    Options
     * @return   string
-    * @throws   Exception           If filetype is not supported
+    * @throws   \Exception          If filetype is not supported
     */
     public function toString ($filetype, $options = NULL) {
         $this->setWriterType($filetype);


### PR DESCRIPTION
+ Catch `libxml` errors in `XMLParser::loadString`
+ PHPDoc block fixes
+ Fixed too late `fclose` in `BaseParser::checkFile`
+ Manually merged changes from #31 by @unreal4u
+ Fixed `SimpleExcel::loadString`
+ Added tests for PHP 5.5 - 5.6
+ `XLSXParser` must implement `loadString`
+ Fixed `HTMLParser::loadString`