### PR TITLE
Fix number datatype identification in XMLWriter

### DIFF
--- a/src/SimpleExcel/Writer/XMLWriter.php
+++ b/src/SimpleExcel/Writer/XMLWriter.php
@@ -70,7 +70,7 @@ class XMLWriter extends BaseWriter implements IWriter
                 $datatype = $val[1];
             } else {
                 $value = $val;
-                $datatype = is_string($val) ? 'String' : (is_numeric($val) ? 'Number' : 'String');
+                $datatype = is_numeric($val) ? 'Number' : 'String';
             }
             
             // escape value from HTML tags


### PR DESCRIPTION
When converting CSV to XML, XMLWriter doesn't recognize numeric values properly. Instead, everything gets cast to string.

The problem seems to be in the wrong order of calling `is_string` and `is_numeric`. To my understanding, the present, wrong order works in no circumstances.

This pull request inverts the order and thus fixes the problem.
